### PR TITLE
Process log files properly when using PARSER=Surelog

### DIFF
--- a/.github/scripts/run_group_test.sh
+++ b/.github/scripts/run_group_test.sh
@@ -75,7 +75,7 @@ for test_case in "${test_cases[@]}"; do
 
     sed -i -n \
         -e "s#${REPO_DIR}/##g" \
-        -e '/1. Executing Verilog with UHDM frontend./,$ {/^End of script/d; /^Time spent/d; p}' \
+        -E -e '/1. Executing (Verilog with )?UHDM frontend./,$ {/^End of script/d; /^Time spent/d; p}' \
         "${test_out_dir}/yosys.log"
 
     # ASAN log contains PID in the name. There should be only one log, but even


### PR DESCRIPTION
The string that is used in sed to cut the interesting part of a log is not supposed to be the same with all the PARSER options. With `PARSER=surelog` it should be `"Executing UHDM frontend"`, while with `PARSER=yosys-plugin` it should be `"Executing Verilog with UHDM frontend"`.

This caused the logs to be empty in one configuration.