### PR TITLE
Bump surelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 __pycache__
 /build
 /image
+.cache/
+compile_commands.json

--- a/frontends/systemverilog/uhdm_ast.cc
+++ b/frontends/systemverilog/uhdm_ast.cc
@@ -4512,6 +4512,16 @@ void UhdmAst::process_longint_typespec()
     current_node->is_signed = vpi_get(vpiSigned, obj_h);
 }
 
+void UhdmAst::process_shortreal_typespec()
+{
+    std::vector<AST::AstNode *> packed_ranges;   // comes before wire name
+    std::vector<AST::AstNode *> unpacked_ranges; // comes after wire name
+    current_node = make_ast_node(AST::AST_WIRE);
+    packed_ranges.push_back(make_range(31, 0));
+    add_multirange_wire(current_node, packed_ranges, unpacked_ranges);
+    current_node->is_signed = vpi_get(vpiSigned, obj_h);
+}
+
 void UhdmAst::process_byte_typespec()
 {
     std::vector<AST::AstNode *> packed_ranges;   // comes before wire name
@@ -5268,6 +5278,9 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
         break;
     case vpiLongIntTypespec:
         process_longint_typespec();
+        break;
+    case vpiShortRealTypespec:
+        process_shortreal_typespec();
         break;
     case vpiTimeTypespec:
         process_time_typespec();

--- a/frontends/systemverilog/uhdm_ast.h
+++ b/frontends/systemverilog/uhdm_ast.h
@@ -160,6 +160,7 @@ class UhdmAst
     void process_int_typespec();
     void process_shortint_typespec();
     void process_longint_typespec();
+    void process_shortreal_typespec();
     void process_time_typespec();
     void process_bit_typespec();
     void process_string_var();

--- a/tests/formal/passlist.txt
+++ b/tests/formal/passlist.txt
@@ -276,6 +276,7 @@ sv2v:core/assert.v
 sv2v:core/case_inside_cast.v
 sv2v:core/class_ident.sv
 sv2v:core/class_ident.v
+sv2v:core/class_param_nest.sv
 sv2v:core/class_param_nest.v
 sv2v:core/constexpr.v
 sv2v:core/data_lifetime.sv
@@ -622,6 +623,7 @@ yosys:simple/case_expr_extend.sv
 yosys:simple/case_expr_query.sv
 yosys:simple/case_large.v
 yosys:simple/constmuldivmod.v
+yosys:simple/constpower.v
 yosys:simple/const_branch_finish.v
 yosys:simple/const_fold_func.v
 yosys:simple/defvalue.sv


### PR DESCRIPTION
Some tests would fail in the automatic PR to bump Surelog:
https://github.com/chipsalliance/synlig/actions/runs/6172468338/job/16753192588?pr=1965

There was an unhandled case in the switch in `process_object`. With this PR it's solved.

I'm also adding files to the `.gitignore` file assuming that such a change doesn't need a separate PR. Please let me know if other solution is preferred.