### PR TITLE
Fix enum item redeclaration error on reimport

### DIFF
--- a/frontends/systemverilog/uhdm_ast.h
+++ b/frontends/systemverilog/uhdm_ast.h
@@ -64,7 +64,7 @@ class UhdmAst
     // Makes the passed node a cell node of the specified type
     void make_cell(vpiHandle obj_h, ::Yosys::AST::AstNode *node, ::Yosys::AST::AstNode *type);
 
-    // Moves a type node to the specified node
+    // Moves a type node to the specified node. If a node of the same name already exists there, the type node is deleted.
     void move_type_to_new_typedef(::Yosys::AST::AstNode *current_node, ::Yosys::AST::AstNode *type_node);
 
     // Go up the UhdmAst to find a parent node of the specified type

--- a/tests/formal/passlist.txt
+++ b/tests/formal/passlist.txt
@@ -79,6 +79,7 @@ simple:EnumConcat/dut.v
 simple:EnumConcatenatedConst/top.sv
 simple:EnumConstX/top.sv
 simple:EnumInPackage/dut.sv
+simple:EnumItemReimport/top.sv
 simple:EnumParameterInNestedModules/top.sv
 simple:EnumVariantInPackage/top.sv
 simple:EnumWidth/top.sv
@@ -338,6 +339,7 @@ sv2v:core/package_export_wildcard.sv
 sv2v:core/package_export_wildcard.v
 sv2v:core/package_global.sv
 sv2v:core/package_global.v
+sv2v:core/package_ident.sv
 sv2v:core/package_ident.v
 sv2v:core/package_implied.sv
 sv2v:core/package_implied.v
@@ -442,6 +444,7 @@ sv2v:relong/complex_interface.sv
 sv2v:relong/complex_interface.v
 sv2v:relong/double_clock.sv
 sv2v:relong/double_clock.v
+sv2v:relong/enum.sv
 sv2v:relong/enum.v
 sv2v:relong/fsm.v
 sv2v:relong/functions.v
@@ -449,6 +452,7 @@ sv2v:relong/gen_struct.sv
 sv2v:relong/gen_struct.v
 sv2v:relong/inline_concat.sv
 sv2v:relong/inline_concat.v
+sv2v:relong/module_struct.sv
 sv2v:relong/module_struct.v
 sv2v:relong/port_connections.sv
 sv2v:relong/port_connections.v

--- a/tests/simple_tests/EnumItemReimport/Makefile.in
+++ b/tests/simple_tests/EnumItemReimport/Makefile.in
@@ -1,0 +1,2 @@
+TOP_FILE := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/simple_tests/EnumItemReimport/top.sv
+++ b/tests/simple_tests/EnumItemReimport/top.sv
@@ -1,0 +1,17 @@
+package adc_ctrl_reg_pkg;
+  typedef enum int {
+    ADC_CTRL_INTR_STATE,
+    ADC_CTRL_INTR_ENABLE
+  } adc_ctrl_id_e;
+endpackage
+
+import adc_ctrl_reg_pkg::* ;
+
+module M();
+  import adc_ctrl_reg_pkg::* ;
+endmodule
+
+module top ();
+  M m1();
+endmodule
+

--- a/tests/simple_tests/EnumItemReimport/yosys_script.tcl
+++ b/tests/simple_tests/EnumItemReimport/yosys_script.tcl
@@ -1,0 +1,6 @@
+source ../yosys_common.tcl
+
+prep -top \\top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd


### PR DESCRIPTION
Fixes #1988.

The error is caused by the enum being added during the iteration of the design, and then again during the iteration of `uhdmtopModules`. Because the original enum is added at the top level, we don't see it so we add it again to individual modules.

Instead of adding typedefs at the top level, this patch makes it so we add it to each top module. Same thing with top-level parameters, as they may require these typedefs.