### PR TITLE
Remove Ubuntu from README and CI

### DIFF
--- a/.github/workflows/tuttest.yml
+++ b/.github/workflows/tuttest.yml
@@ -12,9 +12,10 @@ env:
 jobs:
   test-plugin-from-sources:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy
+    container: debian:bookworm
     env:
       DEBIAN_FRONTEND: noninteractive
+      PIPX_BIN_DIR: /usr/local/bin
 
     steps:
       - name: Prepare Repository
@@ -22,14 +23,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
-
       - name: Install Prerequisites
         run: |
-          apt-get update -qq
-          apt-get install -y python3-pip git
-          pip3 install git+https://github.com/antmicro/tuttest#egg=tuttest
+          apt update -qq
+          apt install -y --no-install-recommends pipx git
+          pipx install git+https://github.com/antmicro/tuttest#egg=tuttest
 
       - name: Install Dependencies
         run: |
@@ -47,48 +45,9 @@ jobs:
           (tuttest README.md path-setup; tuttest README.md example-uhdm-ver2) | bash -
           tuttest README.md example-multiple-files | (. <(tuttest README.md path-setup) && yosys)
 
-  test-plugin-ubuntu:
-    runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy
-    env:
-      DEBIAN_FRONTEND: noninteractive
-
-    steps:
-      - name: Prepare Repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
-
-      - name: Install Prerequisites
-        run: |
-          apt-get update -qq
-          apt-get install -y python3-pip git
-          pip3 install git+https://github.com/antmicro/tuttest#egg=tuttest
-
-      - name: Install Dependencies
-        run: |
-          tuttest README.md install-yosys-ubuntu | bash -
-
-      - name: Install Plugin
-        run: |
-          tuttest README.md download-plugin | bash -
-          tuttest README.md install-plugin | bash -
-
-      - name: Load Plugin
-        run: |
-          tuttest README.md load-plugin | yosys
-
-      - name: Test Plugin
-        run: |
-          tuttest README.md example-verilog | bash -
-          tuttest README.md example-multiple-files | yosys
-
   test-plugin-debian:
     runs-on: [self-hosted, Linux, X64]
-    container: debian:latest
+    container: debian:bookworm
     env:
       DEBIAN_FRONTEND: noninteractive
       PIPX_BIN_DIR: /usr/local/bin
@@ -101,8 +60,8 @@ jobs:
 
       - name: Install Prerequisites
         run: |
-          apt-get update -qq
-          apt-get install -y pipx git
+          apt update -qq
+          apt install -y --no-install-recommends pipx git
           pipx install git+https://github.com/antmicro/tuttest#egg=tuttest
 
       - name: Install Dependencies
@@ -113,10 +72,14 @@ jobs:
         run: |
           tuttest README.md download-plugin | bash -
           tuttest README.md install-plugin | bash -
+          # TODO: temporary fix due to a bug in yosys-config for debian:trixie
+          # ln -s /usr/share/yosys /usr/lib/yosys
 
       - name: Load Plugin
         run: |
-          tuttest README.md load-plugin | yosys
+          tuttest README.md load-plugin | yosys -Q | tee log.txt
+          grep ^ERROR log.txt || exit 0
+          exit 1
 
       - name: Test Plugin
         run: |

--- a/README.md
+++ b/README.md
@@ -15,20 +15,10 @@ Before installing the plugin, check that Yosys is installed and correctly config
    yosys-config --help
 ```
 
-The required Yosys version is 0.10 or later.
+The required Yosys version is 0.23 or later.
 If you don't have Yosys, skip to the [Installation from source](#installation-from-source) section to build Yosys from the source or follow the steps below for Debian-based Linux distributions:
 
-* Ubuntu 22.04 LTS (Jammy Jellyfish) or higher:
-
-<!-- name="install-yosys-ubuntu" -->
-``` bash
-   apt install -y wget
-   wget https://launchpad.net/ubuntu/+source/yosys/0.18-1/+build/24132080/+files/yosys-dev_0.18-1_amd64.deb
-   wget https://launchpad.net/ubuntu/+source/yosys/0.18-1/+build/24132080/+files/yosys_0.18-1_amd64.deb
-   apt install -y ./yosys_0.18-1_amd64.deb ./yosys-dev_0.18-1_amd64.deb
-```
-
-* Debian Sid or higher:
+* Debian Bookworm or higher:
 
 <!-- name="install-yosys-debian" -->
 ``` bash
@@ -53,12 +43,13 @@ The plugin is now ready to be used. and you can go to the [Usage](#usage) sectio
 
 ## Installation from source
 
+* Debian Bookworm:
+
 ### Install dependencies
 
 <!-- name="dependencies" -->
 ``` bash
-   apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev python3-pip uuid uuid-dev tcl-dev flex libfl-dev git pkg-config libreadline-dev bison libffi-dev wget
-   pip3 install orderedmultidict
+   apt install -y gcc-11 g++-11 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev python3-pip uuid uuid-dev tcl-dev flex libfl-dev git pkg-config libreadline-dev bison libffi-dev wget python3-orderedmultidict
 ```
 
 ### Build required binaries

--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
-if [ -z "$INSTALL_PATH" ]; then
-    INSTALL_PATH=$PWD/image
-fi
+: "${VARIABLE:=DEFAULT_VALUE}"
+: "${INSTALL_PATH:=$PWD/image}"
 
 SKIP_YOSYS=0
 BUILD_SV2V=0
@@ -34,20 +33,23 @@ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DCMAKE_PO
 cmake --build build -j $(nproc)
 cmake --install build
 cd ../..
+
 #Yosys
-if [ "$SKIP_YOSYS" -eq "0" ]; then
+if [ "$SKIP_YOSYS" -eq 0 ]; then
 cd third_party/yosys
 make CONFIG=gcc PREFIX=$INSTALL_PATH install -j $(nproc)
 cd ../..
 fi
+
 #UHDM plugin
-if [ "$PLUGIN_ASAN" -eq "1" ]; then
+if [ $PLUGIN_ASAN -eq 1 ]; then
   PLUGIN_LDFLAGS="-fsanitize=address -fcheck-new -fno-omit-frame-pointer -static-libasan"
 fi
 export PATH=$INSTALL_PATH/bin:${PATH}
 UHDM_INSTALL_DIR=$INSTALL_PATH LDFLAGS=$PLUGIN_LDFLAGS make -C $PWD/frontends/systemverilog install -j$(nproc)
+
 #sv2v
-if [ "$BUILD_SV2V" -eq "1" ]; then
+if [ $BUILD_SV2V -eq 1 ]; then
 wget -qO- https://get.haskellstack.org/ | sh -s - -f -d $INSTALL_PATH/bin
 make -j$(nproc) -C $PWD/sv2v && cp $PWD/sv2v/bin/sv2v $INSTALL_PATH/bin
 fi


### PR DESCRIPTION
This PR removes Ubuntu from the README and CI. Also it migrates the source test from Ubuntu to debian:bookworm. This is because we will soon require newer Yosys and only debian (that will be updated to trixie once we bump yosys submodule) contains new enough version.