### PR TITLE
Fix `sv2v` path after moving submodule to `third_party`

### DIFF
--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -50,6 +50,8 @@ UHDM_INSTALL_DIR=$INSTALL_PATH LDFLAGS=$PLUGIN_LDFLAGS make -C $PWD/frontends/sy
 
 #sv2v
 if [ $BUILD_SV2V -eq 1 ]; then
+cd third_party
 wget -qO- https://get.haskellstack.org/ | sh -s - -f -d $INSTALL_PATH/bin
 make -j$(nproc) -C $PWD/sv2v && cp $PWD/sv2v/bin/sv2v $INSTALL_PATH/bin
+cd ..
 fi


### PR DESCRIPTION
Related to https://github.com/chipsalliance/synlig/commit/d7d16c325d55b01e7bd06603420402ff885408a2. Submodules were moved to the `third_party` directory. Paths in `build_binaries.sh` were updated for Surelog and Yosys but not for sv2v.