### PR TITLE
CI: Build release images on debian

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
             build-binaries-args: 'ENABLE_ASAN:=1'
     name: ${{ matrix.name }}
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy
+    container: debian:bookworm
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
@@ -81,9 +81,6 @@ jobs:
         with:
           submodules: false
           fetch-depth: 1
-
-      - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
 
       - name: Install dependencies
         run: |
@@ -106,6 +103,7 @@ jobs:
               python3 \
               python3-dev \
               python3-pip \
+              python3-orderedmultidict \
               swig \
               tcl-dev \
               tclsh \
@@ -114,17 +112,11 @@ jobs:
               wget \
               ${{ matrix.apt-extra-deps }} \
               ;
-          update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-          update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
-          pip install --upgrade pip
-          pip install orderedmultidict
-          pip install cmake
 
       - name: Checkout submodules
         run: |
           git submodule update --depth 1 --init --recursive \
-              third_party/surelog \
-              third_party/yosys \
+              third_party/{surelog,yosys} \
               ;
 
       - name: Setup cache
@@ -293,12 +285,9 @@ jobs:
       - name: Generate tarball and apply TAG
         run: |
           GIT_VERSION=${GIT_VERSION:-$(git rev-parse --short "$GITHUB_SHA")}
-          DISTRO_ARCH=$(uname -m)
-          DISTRO=$(lsb_release --short --id)
-          DISTRO_RELEASE=$(lsb_release --short --release)
-          DISTRO_CODENAME=$(lsb_release --short --codename | sed -e's/[^A-Za-z0-9]//g')
-          FULL_TARBALL=synlig-$GIT_VERSION-$DISTRO-$DISTRO_RELEASE-$DISTRO_CODENAME-$DISTRO_ARCH.tar.gz
-          PLUGIN_TARBALL=synlig-plugin-$GIT_VERSION-$DISTRO-$DISTRO_RELEASE-$DISTRO_CODENAME-$DISTRO_ARCH.tar.gz
+          DATE=$(git show -s --date=short --format=%cd)
+          FULL_TARBALL=synlig-$GIT_VERSION-$DATE.tar.gz
+          PLUGIN_TARBALL=synlig-plugin-$GIT_VERSION-$DATE.tar.gz
           # Create a tag of form 2021-12-06-ad2466e
           TAG="${TAG:-$(git show -s --date=short --format=%cd-%h)}"
           git tag "$TAG" || true


### PR DESCRIPTION
Migrate the build step to Debian.
This is a follow up to #1993