### PR TITLE
Do not pull non-essential submodules by default.

### DIFF
--- a/.github/workflows/bsg-test-diff.yml
+++ b/.github/workflows/bsg-test-diff.yml
@@ -50,7 +50,8 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/bsg_micro_designs \
               ;
 

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -64,7 +64,8 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/yosys \
               third_party/sv2v \
               ;

--- a/.github/workflows/large-designs.yml
+++ b/.github/workflows/large-designs.yml
@@ -53,7 +53,8 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/make_env \
               third_party/ibex \
               ;
@@ -134,7 +135,8 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/make_env \
               third_party/ibex \
               third_party/yosys_f4pga_plugins \
@@ -224,7 +226,8 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/opentitan_9d82960888 \
               ;
 
@@ -335,7 +338,8 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/opentitan \
               ;
 
@@ -436,7 +440,8 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/opentitan \
               ;
 
@@ -544,7 +549,8 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/veer \
               ;
 
@@ -621,10 +627,11 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/black_parrot \
               ;
-          git submodule update --depth 1 --init \
+          git submodule update --depth 1 --init --checkout \
               third_party/black_parrot_tools \
               third_party/black_parrot_sdk \
               ;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,7 +115,8 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/{surelog,yosys} \
               ;
 
@@ -195,7 +196,8 @@ jobs:
       - name: Checkout submodules
         if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/sv2v \
               ;
 

--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -71,7 +71,8 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/surelog \
               ;
 
@@ -167,7 +168,8 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update --depth 1 --init --recursive \
+          git submodule sync
+          git submodule update --depth 1 --init --recursive --checkout \
               third_party/surelog \
               ;
 

--- a/.github/workflows/tuttest.yml
+++ b/.github/workflows/tuttest.yml
@@ -85,3 +85,9 @@ jobs:
         run: |
           tuttest README.md example-verilog | bash -
           tuttest README.md example-multiple-files | yosys
+
+      - name: Test sv2v pull and build
+        run: |
+          export PATH=`pwd`/image/bin:$PATH
+          tuttest README.md sv2v-update | bash -
+          tuttest README.md sv2v-build | bash -

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,36 +7,48 @@
 [submodule "sv2v"]
 	path = third_party/sv2v
 	url = https://github.com/zachjs/sv2v.git
+	update = none
 [submodule "yosys-f4pga-plugins"]
 	path = third_party/yosys_f4pga_plugins
 	url = https://github.com/chipsalliance/yosys-f4pga-plugins.git
+	update = none
 [submodule "make-env"]
 	path = third_party/make_env
 	url = https://github.com/SymbiFlow/make-env.git
+	update = none
 [submodule "uhdm-tests/ibex/ibex"]
 	path = third_party/ibex
 	url = https://github.com/lowRISC/ibex.git
+	update = none
 [submodule "uhdm-tests/opentitan/opentitan-9d82960888"]
 	path = third_party/opentitan_9d82960888
 	url = https://github.com/lowRISC/opentitan.git
+	update = none
 [submodule "uhdm-tests/opentitan/opentitan"]
 	path = third_party/opentitan
 	url = https://github.com/antmicro/opentitan.git
+	update = none
 [submodule "uhdm-tests/black-parrot/black-parrot"]
 	path = third_party/black_parrot
 	url = https://github.com/black-parrot/black-parrot.git
+	update = none
 [submodule "uhdm-tests/black-parrot/black-parrot-tools"]
 	path = third_party/black_parrot_tools
 	url = https://github.com/black-parrot/black-parrot-tools
+	update = none
 [submodule "uhdm-tests/black-parrot/black-parrot-sdk"]
 	path = third_party/black_parrot_sdk
 	url = https://github.com/black-parrot-sdk/black-parrot-sdk.git
+	update = none
 [submodule "uhdm-tests/bsg_micro_designs/bsg_micro_designs"]
 	path = third_party/bsg_micro_designs
 	url = https://github.com/bsg-idea/bsg_micro_designs.git
+	update = none
 [submodule "third_party/veer"]
 	path = third_party/veer
 	url = https://github.com/chipsalliance/Cores-VeeR-EH1
+	update = none
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest
+	update = none

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ You need to add this folder to your `PATH` variable to ensure you are using corr
 
 <!-- name="build-binaries" -->
 ``` bash
+   git submodule sync
    git submodule update --init --recursive third_party/{surelog,yosys}
    ./build_binaries.sh
 ```
@@ -154,6 +155,27 @@ If you encounter any problems with it, please compare the results with a single 
 ## Testing locally
 
 ### Formal Verification
+
+#### Prerequisites
+
+Formal Verification uses `sv2v` tool and tests from its repository, which is available as a submodule.
+To download the sv2v submodule run:
+
+<!-- name="sv2v-update" -->
+``` bash
+   git submodule update --init --recursive --checkout third_party/sv2v
+```
+
+To build sv2v and copy it to `images/bin` (where it is expected to be by the test script) run:
+
+<!-- name="sv2v-build" -->
+``` bash
+wget -qO- https://get.haskellstack.org/ | sh -s - -f -d $PWD/image/bin
+make -j$(nproc) -C $PWD/third_party/sv2v
+cp ./third_party/sv2v/bin/sv2v ./image/bin
+```
+
+#### Testing
 
 To start formal verification tests, use `run_fv_tests.mk`, either as an executable or by using make:
 


### PR DESCRIPTION
Only yosys and surelog submodules are needed for plugin build. Those two are automatically fetched as before, i.e. after calling just `git submodule update --recursive`.

All other submodules are skipped, even when their paths are explicitly specified. To fetch them one has to add `--checkout` flag has to `git submodule update`, e.g.:

```
git submodule update --dept 1 --init --recursive --checkout
```

Fixes #1962