### PR TITLE
Fix plugin install path on Debian

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -459,6 +459,11 @@ jobs:
       PIPX_BIN_DIR: /usr/local/bin
 
     steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: false
+          fetch-depth: 1
+
       - name: Download binaries
         uses: actions/download-artifact@v2
         with:
@@ -471,9 +476,7 @@ jobs:
         run: |
           apt update -q
           apt install -y yosys yosys-dev
-          mkdir -p /usr/lib/yosys/plugins
-          ln -s $PWD/out/current/share/yosys/plugins/systemverilog.so \
-              /usr/lib/yosys/plugins/systemverilog.so
+          ./install_plugin.sh
 
       - name: Load Plugin
         run: |

--- a/install_plugin.sh
+++ b/install_plugin.sh
@@ -15,3 +15,10 @@ SYSTEMVERILOG_PLUGIN_PATH=$INSTALL_SCRIPT_DIR/out/current/share/yosys/plugins/sy
 
 mkdir -p $YOSYS_PLUGIN_DIR
 cp -v $SYSTEMVERILOG_PLUGIN_PATH $YOSYS_PLUGIN_DIR
+
+if [[ -f /etc/os-release ]] && source /etc/os-release && [[ "$NAME" == *Debian* ]]; then
+    # Debian has a different hardcoded plugin path, not reflected in yosys-config
+    # https://salsa.debian.org/science-team/yosys/-/blob/master/debian/patches/0017-Support-plugin-loading-from-libdir.patch
+    mkdir -p /usr/lib/yosys/plugins
+    cp $SYSTEMVERILOG_PLUGIN_PATH /usr/lib/yosys/plugins
+fi

--- a/install_plugin.sh
+++ b/install_plugin.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Yosys packaged for Debian > 12 expects plugins in a different directory than the one given by `yosys-config`.