### PR TITLE
Don't hardcode location of bash and python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Setup make itself.
 
 .ONESHELL:
-override SHELL := /bin/bash
+SHELL := bash
 override .SHELLFLAGS := -e -u -o pipefail -O nullglob -O extglob -O globstar -c
 
 # Unset all default build- and recipe-related variables.

--- a/build_binaries.mk
+++ b/build_binaries.mk
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S make -rR -Oline -f
 .ONESHELL:
-override SHELL := /bin/bash
+SHELL := bash
 override .SHELLFLAGS := -e -u -o pipefail -O nullglob -O extglob -O globstar -c
 
 override this_mk.file := $(abspath $(lastword ${MAKEFILE_LIST}))

--- a/run_fv_tests.mk
+++ b/run_fv_tests.mk
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S make -rR -Otarget -f
 .ONESHELL:
-override SHELL := /bin/bash
+SHELL := bash
 override .SHELLFLAGS := -e -u -o pipefail -O nullglob -O extglob -O globstar -c
 
 override this_mk.file := $(abspath $(lastword ${MAKEFILE_LIST}))

--- a/tests/lib/testhandlers/formalverification.py
+++ b/tests/lib/testhandlers/formalverification.py
@@ -252,7 +252,7 @@ class BashScriptTaskGenerator:
 			return v
 
 		lines: list[str] = [
-			r"#!/bin/bash",
+			r"#!/usr/bin/env bash",
 			"set -u -o pipefail",
 			"shopt -s nullglob",
 			"shopt -s extglob",

--- a/tests/list.py
+++ b/tests/list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse
 import json
@@ -26,6 +26,6 @@ if args.directory[-1] == "/":
 part_of_tests = sorted(os.listdir(args.directory))
 if args.part is not None:
     part_of_tests = part_of_tests[(args.part - 1) * 256 : args.part * 256]
-    
+
 print(json.dumps([f"{args.directory}/{node}" for node in part_of_tests
     if node not in args.skip_elements and os.path.isdir(args.directory + "/" + node)]))

--- a/tests/opentitan/opentitan_parsing_test/Makefile
+++ b/tests/opentitan/opentitan_parsing_test/Makefile
@@ -1,5 +1,5 @@
 .ONESHELL:
-override SHELL := /bin/bash
+SHELL := bash
 override .SHELLFLAGS := -e -u -o pipefail -O nullglob -O extglob -c
 
 override this_mk.file := $(abspath $(lastword ${MAKEFILE_LIST}))

--- a/tests/opentitan/opentitan_parsing_test/Makefile.scripts.sh
+++ b/tests/opentitan/opentitan_parsing_test/Makefile.scripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 declare -r result_unknown='unknown'
 
 declare -r result_test_pass='test-pass'


### PR DESCRIPTION
Bash is not always located /bin/bash
In Makefiles, use just 'bash' so that it is found from the path; also make it possible to override on the command line if needed.

Replace #!/bin/bash in scripts with #!/usr/bin/env bash

Also fix one instance of #!/usr/bin/python to #!/usr/bin/env python