### PR TITLE
Remove linker option that fails on Mac/Darwin

### DIFF
--- a/frontends/systemverilog/Build.mk
+++ b/frontends/systemverilog/Build.mk
@@ -54,8 +54,7 @@ ${ts}.ldflags = \
 	$(if ${LD},${USE_LD_FLAG}) \
 	$(shell ${${ts}.env}; pkg-config --libs-only-L Surelog) \
 	${build_type_ldflags} \
-	${LDFLAGS} \
-	-Wl,--export-dynamic
+	${LDFLAGS}
 
 ${ts}.ldlibs = \
 	$(shell ${${ts}.env}; pkg-config --libs-only-l --libs-only-other Surelog) \


### PR DESCRIPTION
There is no --export-dynamic linker option on clang11 on Darwin, so compile fails there with
```
  ld: unknown option: --export-dynamic
```

Without this option, the plug-in works as well, so remove it.