### PR TITLE
Fix CMake build on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,14 @@ set_target_properties(
   synlig PROPERTIES SOVERSION "${SYNLIG_VERSION_MAJOR}.${SYNLIG_VERSION_MINOR}")
 set_target_properties(synlig PROPERTIES OUTPUT_NAME "systemverilog")
 set_target_properties(synlig PROPERTIES PREFIX "")
+set_target_properties(synlig PROPERTIES SUFFIX ".so")
+
+# Allow undefined symbols at link time on macOS. These symbols should already be
+# present within yosys when the plugin is loaded.
+if(APPLE)
+  set_target_properties(synlig PROPERTIES LINK_FLAGS
+                                          "-undefined dynamic_lookup")
+endif()
 
 target_include_directories(
   synlig


### PR DESCRIPTION
The new CMake-based build system almost works on macOS, but fails at the final step when linking the plugin. This is because the default behavior on macOS (for both clang and GCC) is to require all symbols to be defined at link time for a dynamic library. This is not the case for synlig, so it fails to link.

<details>
<summary>Failing linker output</summary>

```
[100%] Linking CXX shared library /opt/synlig/install/share/yosys/plugins/systemverilog.dylib
ld: warning: ignoring duplicate libraries: 'third_party/surelog/third_party/UHDM/lib/libuhdm.a'
ld: Undefined symbols:
  Yosys::log_header(Yosys::RTLIL::Design*, char const*, ...), referenced from:
      systemverilog_plugin::UhdmAstFrontend::call_log_header(Yosys::RTLIL::Design*) in uhdm_ast_frontend.cc.o
      systemverilog_plugin::UhdmSurelogAstFrontend::call_log_header(Yosys::RTLIL::Design*) in uhdm_surelog_ast_frontend.cc.o
      systemverilog_plugin::SynligEdifBackend::execute(std::__1::basic_ostream<char, std::__1::char_traits<char>>*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, Yosys::RTLIL::Design*) in synlig_edif.cc.o
  Yosys::log_signal(Yosys::RTLIL::SigSpec const&, bool), referenced from:
      systemverilog_plugin::SynligEdifBackend::execute(std::__1::basic_ostream<char, std::__1::char_traits<char>>*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, Yosys::RTLIL::Design*) in synlig_edif.cc.o
      systemverilog_plugin::SynligEdifBackend::execute(std::__1::basic_ostream<char, std::__1::char_traits<char>>*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, Yosys::RTLIL::Design*) in synlig_edif.cc.o
      systemverilog_plugin::SynligEdifBackend::execute(std::__1::basic_ostream<char, std::__1::char_traits<char>>*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, Yosys::RTLIL::Design*) in synlig_edif.cc.o
      systemverilog_plugin::SynligEdifBackend::execute(std::__1::basic_ostream<char, std::__1::char_traits<char>>*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, Yosys::RTLIL::Design*) in synlig_edif.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
  Yosys::logv_error(char const*, __va_list_tag*), referenced from:
      systemverilog_plugin::UhdmAst::report_error(char const*, ...) const in uhdm_ast.cc.o
  Yosys::log_warning(char const*, ...), referenced from:
      systemverilog_plugin::UhdmAst::process_object(unsigned int*) in uhdm_ast.cc.o
      systemverilog_plugin::UhdmAst::process_design() in uhdm_ast.cc.o
      systemverilog_plugin::UhdmAst::process_operation(UHDM::BaseClass const*) in uhdm_ast.cc.o
      systemverilog_plugin::UhdmAst::process_operation(UHDM::BaseClass const*) in uhdm_ast.cc.o
      systemverilog_plugin::UhdmAst::process_unsupported_stmt(UHDM::BaseClass const*, bool) in uhdm_ast.cc.o
      systemverilog_plugin::const2ast(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, char, bool) in synlig_const2ast.cc.o
      my_strtobin(std::__1::vector<Yosys::RTLIL::State, std::__1::allocator<Yosys::RTLIL::State>>&, char const*, int, int, char, bool) in synlig_const2ast.cc.o
      ...
  Yosys::AST_INTERNAL::current_ast, referenced from:
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
  Yosys::AST_INTERNAL::flag_mem2reg, referenced from:
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
  Yosys::AST_INTERNAL::current_block, referenced from:
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      ...
  Yosys::AST_INTERNAL::current_scope, referenced from:
      systemverilog_plugin::UhdmAst::process_design() in uhdm_ast.cc.o
      systemverilog_plugin::UhdmAst::process_design() in uhdm_ast.cc.o
      systemverilog_plugin::UhdmAst::process_design() in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      ...
  Yosys::AST_INTERNAL::flag_autowire, referenced from:
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
  Yosys::AST_INTERNAL::current_always, referenced from:
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      ...
  Yosys::AST_INTERNAL::flag_nomem2reg, referenced from:
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
  Yosys::AST_INTERNAL::flag_nomeminit, referenced from:
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
  Yosys::AST_INTERNAL::current_ast_mod, referenced from:
      systemverilog_plugin::UhdmAst::process_design() in uhdm_ast.cc.o
      systemverilog_plugin::UhdmAst::process_design() in uhdm_ast.cc.o
      systemverilog_plugin::setup_current_scope(std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, Yosys::AST::AstNode*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, Yosys::AST::AstNode*>>>, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::simplify_sv(Yosys::AST::AstNode*, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::UhdmAst::simplify_parameter(Yosys::AST::AstNode*, Yosys::AST::AstNode*) in uhdm_ast.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      ...
  Yosys::AST_INTERNAL::current_top_block, referenced from:
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
  Yosys::AST_INTERNAL::current_block_child, referenced from:
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      ...
  Yosys::AST_INTERNAL::current_memwr_count, referenced from:
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
  Yosys::AST_INTERNAL::current_memwr_visible, referenced from:
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      ...
  Yosys::AST_INTERNAL::current_always_clocked, referenced from:
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      systemverilog_plugin::simplify(Yosys::AST::AstNode*, bool, bool, bool, int, int, bool, bool) in synlig_simplify.cc.o
      ...
[more...]
```

</details>

This PR adds the `-undefined dynamic_lookup` flag when built under macOS to allow undefined symbols at link time, similar to the behavior under Linux.

Additionally, yosys looks for plugins with a `.so` extension, so this is enforced instead of the macOS default of `.dylib`.

Works on macOS 14.1 with clang 15 and CMake 3.27.7