### PR TITLE
Introduce a compatibility layer for Yosys::AST::process

### DIFF
--- a/frontends/systemverilog/compat_symbols.cc
+++ b/frontends/systemverilog/compat_symbols.cc
@@ -8,4 +8,21 @@ YOSYS_NAMESPACE_BEGIN
 #include "kernel/constids.inc"
 #undef X
 
+#ifdef __linux__
+namespace AST
+{
+extern void process(Design *, AstNode *, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool,
+                    bool, bool, bool);
+
+void __attribute__((weak))
+process(RTLIL::Design *design, AST::AstNode *ast, bool dump_ast1, bool dump_ast2, bool no_dump_ptr, bool dump_vlog1, bool dump_vlog2, bool dump_rtlil,
+        bool nolatches, bool nomeminit, bool nomem2reg, bool mem2reg, bool noblackbox, bool lib, bool nowb, bool noopt, bool icells, bool pwires,
+        bool nooverwrite, bool overwrite, bool defer, bool autowire)
+{
+    process(design, ast, false, dump_ast1, dump_ast2, no_dump_ptr, dump_vlog1, dump_vlog2, dump_rtlil, nolatches, nomeminit, nomem2reg, mem2reg,
+            noblackbox, lib, nowb, noopt, icells, pwires, nooverwrite, overwrite, defer, autowire);
+}
+
+} // namespace AST
+#endif
 YOSYS_NAMESPACE_END

--- a/frontends/systemverilog/uhdm_common_frontend.cc
+++ b/frontends/systemverilog/uhdm_common_frontend.cc
@@ -20,6 +20,20 @@
 #include "uhdm_common_frontend.h"
 #include "synlig_edif.h"
 
+#ifdef __linux__
+namespace Yosys
+{
+using AST::AstNode;
+using RTLIL::Design;
+
+namespace AST
+{
+extern void process(Design *, AstNode *, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool,
+                    bool, bool);
+} // namespace AST
+} // namespace Yosys
+#endif
+
 namespace systemverilog_plugin
 {
 
@@ -151,8 +165,8 @@ void UhdmCommonFrontend::execute(std::istream *&f, std::string filename, std::ve
     AST::AstNode *current_ast = parse(filename);
 
     if (current_ast) {
-        AST::process(design, current_ast, dump_ast1, dump_ast2, no_dump_ptr, dump_vlog1, dump_vlog2, dump_rtlil, false, false, false, false, false,
-                     false, false, false, false, false, dont_redefine, false, defer, default_nettype_wire);
+        Yosys::AST::process(design, current_ast, dump_ast1, dump_ast2, no_dump_ptr, dump_vlog1, dump_vlog2, dump_rtlil, false, false, false, false,
+                            false, false, false, false, false, false, dont_redefine, false, defer, default_nettype_wire);
         delete current_ast;
     }
 }

--- a/frontends/systemverilog/uhdm_common_frontend.cc
+++ b/frontends/systemverilog/uhdm_common_frontend.cc
@@ -159,14 +159,25 @@ void UhdmCommonFrontend::execute(std::istream *&f, std::string filename, std::ve
     AST::set_line_num = &set_line_num;
     AST::get_line_num = &get_line_num;
 
-    bool dont_redefine = false;
-    bool default_nettype_wire = true;
-
     AST::AstNode *current_ast = parse(filename);
 
     if (current_ast) {
-        Yosys::AST::process(design, current_ast, dump_ast1, dump_ast2, no_dump_ptr, dump_vlog1, dump_vlog2, dump_rtlil, false, false, false, false,
-                            false, false, false, false, false, false, dont_redefine, false, defer, default_nettype_wire);
+        Yosys::AST::process(design, current_ast, dump_ast1, dump_ast2, no_dump_ptr, dump_vlog1, dump_vlog2, dump_rtlil,
+                            false, // nolatches
+                            false, // nomeminit
+                            false, // nomem2reg
+                            false, // mem2reg
+                            false, // noblackbox
+                            false, // lib
+                            false, // nowb
+                            false, // noopt
+                            false, // icells
+                            false, // pwires
+                            false, // nooverwrite
+                            false, // overwrite
+                            defer, // defer
+                            true   // autowire
+        );
         delete current_ast;
     }
 }


### PR DESCRIPTION
This uses a weak symbol which allows us to build and link with Yosys before and after the API change.

Ref: #2300