### PR TITLE
Run AST diff job on push event

### DIFF
--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -222,7 +222,7 @@ jobs:
     name: Generate AST diff
     runs-on: [self-hosted, Linux, X64, gcp-custom-runners]
     container: ubuntu:jammy
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event.push
     needs:
       - tests-read-systemverilog
     steps:


### PR DESCRIPTION
Currently logs are only pushed on pull request event.

This means, logs are not updated on main branch after pull request merge.