### PR TITLE
Add debian mirrors

### DIFF
--- a/.github/scripts/set-up-common-git-configuration.sh
+++ b/.github/scripts/set-up-common-git-configuration.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+begin_group() { printf '::group::%s\n' "$*"; }
+end_group() { printf '::endgroup::\n'; }
+
+#-----------------------------------------------------------------------------
+begin_group 'Configure git'
+#-----------------------------------------------------------------------------
+
+# Use "some reasonable default" parallel fetch operations.
+# https://git-scm.com/docs/git-config#Documentation/git-config.txt-fetchparallel
+cat >> ~/.gitconfig <<-EOF
+[fetch]
+	parallel=0
+EOF
+# Github dropped support for unauthorized git:
+# https://github.blog/2021-09-01-improving-git-protocol-security-github/
+# Make sure we always use https:// instead of git://
+cat >> ~/.gitconfig <<-EOF
+[url "https://github.com/"]
+	insteadOf=git://github.com/
+EOF
+
+end_group
+
+#-----------------------------------------------------------------------------

--- a/.github/workflows/bsg-test-diff.yml
+++ b/.github/workflows/bsg-test-diff.yml
@@ -21,7 +21,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -36,7 +36,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/large-designs.yml
+++ b/.github/workflows/large-designs.yml
@@ -21,7 +21,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |
@@ -102,7 +104,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |
@@ -192,7 +196,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |
@@ -304,7 +310,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |
@@ -401,7 +409,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |
@@ -516,7 +526,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |
@@ -597,7 +609,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |
@@ -682,7 +696,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,11 @@ jobs:
           submodules: false
           fetch-depth: 1
 
+      - name: Set up common configuration
+        run: |
+          ./.github/scripts/set-up-common-debian-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
+
       - name: Install dependencies
         run: |
           apt-get update -q
@@ -185,7 +190,7 @@ jobs:
   build-sv2v:
     name: Build sv2v
     runs-on: [self-hosted, Linux, X64, gcp-custom-runners]
-    container: ubuntu:jammy
+    container: debian:bookworm
     env:
       DEBIAN_FRONTEND: noninteractive
       GHA_MACHINE_TYPE: "n2-standard-4"
@@ -196,8 +201,10 @@ jobs:
           submodules: false
           fetch-depth: 1
 
-      - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+      - name: Set up common Debian configuration
+        run: |
+          ./.github/scripts/set-up-common-debian-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -43,7 +43,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |
@@ -140,7 +142,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |
@@ -237,7 +241,9 @@ jobs:
           path: logs
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Install dependencies
         run: |
@@ -317,7 +323,9 @@ jobs:
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
-        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+        run: |
+          ./.github/scripts/set-up-common-ubuntu-configuration.sh
+          ./.github/scripts/set-up-common-git-configuration.sh
 
       - name: Download test results
         uses: /actions/download-artifact@v3


### PR DESCRIPTION
This PR adds script to setup debian mirrors to limit CI failures due to connection errors with debian repository mirrors.