### PR TITLE
Add missing permissions for release job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -288,6 +288,8 @@ jobs:
     needs: build-binaries
 
   release:
+    permissions:
+      contents: write
     name: Release Package
     needs:
       - build-binaries


### PR DESCRIPTION
Github requires `contents: write` permission to create release: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview