### PR TITLE
Update yosys; rework AST_GENBLOCK's handling

### DIFF
--- a/.ci.yml
+++ b/.ci.yml
@@ -1,16 +1,35 @@
 stages:
-  - install_requirements_and_build
-  - run_tests
+  - check_code_format
+  - build_binaries
+  - run_parsing_and_formal_tests
+  - verify_formal_tests_passlist
+  - run_large_designs_tests
+  - optional_bsg_tests
 
 image: debian:bookworm
 
-install_requirements_and_build:
-  stage: install_requirements_and_build
+check_format:
+  stage: check_code_format
+  script:
+    - echo "Install dependencies"
+    - apt update && apt install -y git clang-format
+    - echo "Check code format"
+    - ./.github/scripts/format_sources.sh
+    - if ! git diff --exit-code; then
+    -   echo "Format locally using ./.github/scripts/format_sources.sh"
+    -   /bin/false
+    - fi
+
+build_binaries:
+  stage: build_binaries
   variables:
     SCALENODE_RAM: 8000
-    SCALENODE_CPU: 6
+    SCALENODE_CPU: 8
+  only:
+    - main
+    - merge_requests
   script:
-    - echo "Installing dependencies and build"
+    - echo "Install dependencies and build"
     - apt update
     - >
         apt install -y gcc-11 g++-11 build-essential
@@ -29,6 +48,7 @@ install_requirements_and_build:
     - make -j$(nproc) -C $PWD/third_party/sv2v
     - cp third_party/sv2v/bin/sv2v out/release/bin/
   artifacts:
+    when: always
     paths:
       - out/
 
@@ -47,16 +67,21 @@ variables:
     NestedStructArrayParameterInitializedByPatternPassedAsPort PartSelectInFor SelfSelectsInBitSelectAfterBitSelect
     StructArrayParameterInitializedByPatternPassedAsPort SelectGivenBySelectOnParameterInFunction StreamOperatorBitReverseFunction
   DEPENDENCIES_FOR_TESTING: >
-    make libgoogle-perftools4 libgoogle-perftools-dev libreadline8 gcc-11
-    libtcl8.6 libffi-dev tcl-dev flex libfl-dev swig g++-11 build-essential
-    jq git python3 python3-dev python3-pip python3-orderedmultidict
+    make libgoogle-perftools4 libgoogle-perftools-dev libreadline8 gcc-11 bison
+    libtcl8.6 libffi-dev tcl-dev flex libfl-dev swig g++-11 build-essential cmake
+    jq git python3 python3-dev python3-pip python3-orderedmultidict libreadline-dev
+    default-jre gettext-base ant libcairo2-dev google-perftools libtinfo5 wget
+    uuid-dev uuid libftdi1-dev ninja-build srecord tclsh time rustc graphviz-dev
 
 parsing_tests_read_uhdm:
-  stage: run_tests
+  stage: run_parsing_and_formal_tests
   variables:
     PARSER: surelog
     TARGET: uhdm/yosys/test-ast
-  dependencies: [install_requirements_and_build]
+  dependencies: [build_binaries]
+  only:
+    - main
+    - merge_requests
   script:
     - echo "Install dependencies"
     - apt update
@@ -67,15 +92,19 @@ parsing_tests_read_uhdm:
     - echo "Start testing"
     - ./.github/scripts/run_group_test.sh ./build/parsing/read-uhdm ./build/parsing/test-results-uhdm.log
   artifacts:
+    when: always
     paths:
       - build/
 
 parsing_tests_read_systemverilog:
-  stage: run_tests
+  stage: run_parsing_and_formal_tests
   variables:
     PARSER: yosys-plugin
     TARGET: uhdm/yosys/test-ast
-  dependencies: [install_requirements_and_build]
+  dependencies: [build_binaries]
+  only:
+    - main
+    - merge_requests
   script:
     - echo "Install dependencies"
     - apt update
@@ -86,18 +115,22 @@ parsing_tests_read_systemverilog:
     - echo "Start testing"
     - ./.github/scripts/run_group_test.sh ./build/parsing/read-systemverilog ./build/parsing/test-results-systemverilog.log
   artifacts:
+    when: always
     paths:
       - build/
 
 formal_verification_simple_tests:
-  stage: run_tests
+  stage: run_parsing_and_formal_tests
   variables:
     PARSER: yosys-plugin
     SCALENODE_RAM: 8000
     SCALENODE_CPU: 6
     NAME: simple
     DIR: ./tests/simple_tests
-  dependencies: [install_requirements_and_build]
+  dependencies: [build_binaries]
+  only:
+    - main
+    - merge_requests
   script:
     - echo "Install dependencies"
     - apt update
@@ -114,18 +147,22 @@ formal_verification_simple_tests:
     - set -o pipefail
     - python3 ./tests/formal/results.py "build/tests/${NAME}" | tee "build/${NAME}_summary.txt"
   artifacts:
+    when: always
     paths:
       - build/
 
 formal_verification_yosys_tests:
-  stage: run_tests
+  stage: run_parsing_and_formal_tests
   variables:
     PARSER: yosys-plugin
     SCALENODE_RAM: 8000
     SCALENODE_CPU: 6
     NAME: yosys
     DIR: ./third_party/yosys/tests
-  dependencies: [install_requirements_and_build]
+  dependencies: [build_binaries]
+  only:
+    - main
+    - merge_requests
   script:
     - echo "Install dependencies"
     - apt update
@@ -145,18 +182,22 @@ formal_verification_yosys_tests:
     - set -o pipefail
     - python3 ./tests/formal/results.py "build/tests/${NAME}" | tee "build/${NAME}_summary.txt"
   artifacts:
+    when: always
     paths:
       - build/
 
 formal_verification_sv2v_tests:
-  stage: run_tests
+  stage: run_parsing_and_formal_tests
   variables:
     PARSER: yosys-plugin
     SCALENODE_RAM: 8000
     SCALENODE_CPU: 6
     NAME: sv2v
     DIR: ./third_party/sv2v/test
-  dependencies: [install_requirements_and_build]
+  dependencies: [build_binaries]
+  only:
+    - main
+    - merge_requests
   script:
     - echo "Install dependencies"
     - apt update
@@ -176,6 +217,324 @@ formal_verification_sv2v_tests:
     - set -o pipefail
     - python3 ./tests/formal/results.py "build/tests/${NAME}" | tee "build/${NAME}_summary.txt"
   artifacts:
+    when: always
     paths:
       - build/
 
+verify_formal_tests_passlist:
+  stage: verify_formal_tests_passlist
+  dependencies: [formal_verification_simple_tests, formal_verification_yosys_tests, formal_verification_sv2v_tests]
+  only:
+    - main
+    - merge_requests
+  script:
+    - echo "Check if every test from passlist.txt was executed"
+    - sort build/*.performed_tests_list.txt > performed_tests_list.txt
+    - cat tests/formal/passlist.txt | sed '/^#/d' | sort > sorted_passlist.txt
+    - readarray not_performed_tests < <(comm -13 performed_tests_list.txt sorted_passlist.txt)
+    - if (( ${#not_performed_tests[@]} > 0 )); then
+    -   printf '\x1b[1mTests from passlist.txt that were not performed:\x1b[0m\n'
+    -   printf '\x1b[91m%s\x1b[0m\n' "${not_performed_tests[@]}"
+    -   exit 1
+    - else
+    -   exit 0
+    - fi
+
+veer_synth_large_design:
+  stage: run_large_designs_tests
+  dependencies: [build_binaries]
+  variables:
+    SCALENODE_RAM: 12000
+    SCALENODE_CPU: 4
+  only:
+    - main
+    - merge_requests
+  script:
+    - echo "Install dependencies"
+    - apt update
+    - apt install -y $DEPENDENCIES_FOR_TESTING
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    - update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+    - echo "Load submodules"
+    - git submodule sync
+    - git submodule update --depth 1 --init --recursive --checkout third_party/veer
+    - echo "Start testing"
+    - pip install --break-system-packages virtualenv && export PATH="$PATH:/usr/local/bin"
+    - make -C tests uhdm/yosys/veer TEST=veer ENABLE_READLINE=0 PRETTY=0 -j $(nproc)
+  artifacts:
+    when: always
+    paths:
+      - tests/build/
+
+blackparrot_synth_AMD_xilinx_large_design:
+  stage: run_large_designs_tests
+  dependencies: [build_binaries]
+  only:
+    - main
+    - merge_requests
+  variables:
+    SCALENODE_RAM: 20000
+    SCALENODE_CPU: 6
+  script:
+    - echo "Install dependencies"
+    - apt update
+    - apt install -y $DEPENDENCIES_FOR_TESTING
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    - update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+    - echo "Load submodules"
+    - git submodule sync
+    - git submodule update --depth 1 --init --recursive --checkout third_party/black_parrot
+    - git submodule update --depth 1 --init --checkout third_party/{black_parrot_tools,black_parrot_sdk}
+    - echo "Start testing"
+    - pip install --break-system-packages virtualenv && export PATH="$PATH:/usr/local/bin"
+    - make -C tests uhdm/yosys/synth-blackparrot-build TEST=black_parrot ENABLE_READLINE=0 PRETTY=0 -j $(nproc)
+  artifacts:
+    when: always
+    paths:
+      - tests/build/
+
+blackparrot_synth_ASIC_xilinx_large_design:
+  stage: run_large_designs_tests
+  dependencies: [build_binaries]
+  only:
+    - main
+    - merge_requests
+  variables:
+    SCALENODE_RAM: 20000
+    SCALENODE_CPU: 6
+  script:
+    - echo "Install dependencies"
+    - apt update
+    - apt install -y $DEPENDENCIES_FOR_TESTING
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    - update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+    - echo "Load submodules"
+    - git submodule sync
+    - git submodule update --depth 1 --init --recursive --checkout third_party/black_parrot
+    - git submodule update --depth 1 --init --checkout third_party/{black_parrot_tools,black_parrot_sdk,OpenROAD-flow-scripts}
+    - echo "Start testing"
+    - pip install --break-system-packages virtualenv && export PATH="$PATH:/usr/local/bin"
+    - make -C tests uhdm/yosys/synth-blackparrot-build-asic TEST=black_parrot -j $(nproc)
+  artifacts:
+    when: always
+    paths:
+      - tests/build/
+      - third_party/OpenROAD-flow-scripts/logs
+      - third_party/OpenROAD-flow-scripts/reports
+      - third_party/OpenROAD-flow-scripts/results
+
+ibex_synth_large_design:
+  stage: run_large_designs_tests
+  dependencies: [build_binaries]
+  only:
+    - main
+    - merge_requests
+  variables:
+    SCALENODE_RAM: 16000
+    SCALENODE_CPU: 6
+  script:
+    - echo "Install dependencies"
+    - apt update
+    - apt install -y $DEPENDENCIES_FOR_TESTING
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    - update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+    - echo "Load submodules"
+    - git submodule sync
+    - git submodule update --depth 1 --init --recursive --checkout third_party/{make_env,ibex}
+    - echo "Setup tools"
+    - eval $SETUP_TOOLS && export PATH="$PATH:$TOOLS_HOME/bin"
+    - echo "Start testing"
+    - pip install --break-system-packages virtualenv && export PATH="$PATH:/usr/local/bin"
+    - make -C tests uhdm/yosys/synth-ibex-build TEST=ibex ENABLE_READLINE=0 PRETTY=0 -j $(nproc)
+  artifacts:
+    when: always
+    paths:
+      - tests/build/
+
+ibex_synth_f4pga_large_design:
+  stage: run_large_designs_tests
+  dependencies: [build_binaries]
+  only:
+    - main
+    - merge_requests
+  variables:
+    SCALENODE_RAM: 20000
+    SCALENODE_CPU: 6
+  script:
+    - echo "Install dependencies"
+    - apt update
+    - apt install -y $DEPENDENCIES_FOR_TESTING
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    - update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+    - echo "Load submodules"
+    - git submodule sync
+    - git submodule update --depth 1 --init --recursive --checkout third_party/{make_env,ibex,yosys_f4pga_plugins}
+    - echo "Setup tools"
+    - eval $SETUP_TOOLS && export PATH="$PATH:$TOOLS_HOME/bin"
+    - echo "Start testing"
+    - pip install --break-system-packages virtualenv && export PATH="$PATH:/usr/local/bin"
+    - make -C ./tests env TEST=ibex -j1
+    - make -C tests uhdm/yosys/synth-ibex-f4pga TEST=ibex ENABLE_READLINE=0 PRETTY=0 -j $(nproc)
+  artifacts:
+    when: always
+    paths:
+      - tests/build/
+
+
+opentitan_9d82960888_synth_large_design:
+  stage: run_large_designs_tests
+  dependencies: [build_binaries]
+  only:
+    - main
+    - merge_requests
+  variables:
+    SCALENODE_RAM: 50000
+    SCALENODE_CPU: 6
+  script:
+    - echo "Install dependencies"
+    - apt update
+    - apt install -y $DEPENDENCIES_FOR_TESTING
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    - update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+    - echo "Load submodules"
+    - git submodule sync
+    - git submodule update --depth 1 --init --recursive --checkout third_party/opentitan_9d82960888
+    - echo "Setup tools"
+    - eval $SETUP_TOOLS && export PATH="$PATH:$TOOLS_HOME/bin"
+    - echo "Start testing"
+    - pip install --break-system-packages virtualenv && export PATH="$PATH:/usr/local/bin"
+    - make -C tests uhdm/yosys/synth-opentitan-build TEST=opentitan ENABLE_READLINE=0 PRETTY=0 -j $(nproc)
+  artifacts:
+    when: always
+    paths:
+      - tests/build/
+
+opentitan_synth_large_design:
+  stage: run_large_designs_tests
+  tags: ['ace-x86_64-high-mem']
+  dependencies: [build_binaries]
+  when: manual
+  only:
+    - main
+    - merge_requests
+  variables:
+    SCALENODE_RAM: 160000
+    SCALENODE_CPU: 6
+  script:
+    - echo "Install dependencies"
+    - apt update
+    - apt install -y $DEPENDENCIES_FOR_TESTING
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    - update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+    - echo "Load submodules"
+    - git submodule sync
+    - git submodule update --depth 1 --init --recursive --checkout third_party/opentitan
+    - echo "Setup tools"
+    - eval $SETUP_TOOLS && export PATH="$PATH:$TOOLS_HOME/bin"
+    - echo "Start testing"
+    - pip install --break-system-packages virtualenv && export PATH="$PATH:/usr/local/bin"
+    - make -C tests uhdm/yosys/synth-opentitan-build-tiny TEST=opentitan ENABLE_READLINE=0 PRETTY=0 -j $(nproc)
+  artifacts:
+    when: always
+    paths:
+      - tests/build/
+
+opentitan_parse_report_quick_large_design:
+  stage: run_large_designs_tests
+  dependencies: [build_binaries]
+  only:
+    - main
+    - merge_requests
+  variables:
+    SCALENODE_RAM: 36000
+    SCALENODE_CPU: 6
+  script:
+    - echo "Install dependencies"
+    - apt update
+    - apt install -y $DEPENDENCIES_FOR_TESTING
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    - update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+    - pip install --break-system-packages virtualenv && export PATH="$PATH:/usr/local/bin"
+    - echo "Load submodules"
+    - git submodule sync
+    - git submodule update --depth 1 --init --recursive --checkout third_party/opentitan
+    - echo "Setup tools"
+    - eval $SETUP_TOOLS && export PATH="$PATH:$TOOLS_HOME/bin"
+    - echo "Create venv"
+    - export PATH="$PWD/out/current/bin:$PATH"
+    - cd tests/opentitan/opentitan_parsing_test
+    - make gen-opentitan-deps-mk
+    - echo "Run parsing tests"
+    - make -rR -j$(nproc) -Otarget test || /bin/true
+    - echo "Make summary"
+    - make summary
+    - make summary.md
+    - cat build/results/summary.md && rm build/results/summary.md
+    - make check-status
+  artifacts:
+    when: always
+    paths:
+      - tests/opentitan/opentitan_parsing_test/build/
+
+opentitan_parse_report_full_large_design:
+  stage: run_large_designs_tests
+  tags: ['ace-x86_64-high-mem']
+  dependencies: [build_binaries]
+  when: manual
+  only:
+    - main
+    - merge_requests
+  variables:
+    SCALENODE_RAM: 120000
+    SCALENODE_CPU: 6
+  script:
+    - echo "Install dependencies"
+    - apt update
+    - apt install -y $DEPENDENCIES_FOR_TESTING
+    - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    - update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+    - pip install --break-system-packages virtualenv && export PATH="$PATH:/usr/local/bin"
+    - echo "Load submodules"
+    - git submodule sync
+    - git submodule update --depth 1 --init --recursive --checkout third_party/opentitan
+    - echo "Setup tools"
+    - eval $SETUP_TOOLS && export PATH="$PATH:$TOOLS_HOME/bin"
+    - echo "Create venv"
+    - export PATH="$PWD/out/current/bin:$PATH"
+    - cd tests/opentitan/opentitan_parsing_test
+    - make gen-opentitan-deps-mk
+    - echo "Run parsing tests"
+    - make -rR -j$(nproc) TOP_DOWN_TEST:=1 -Otarget test || /bin/true
+    - echo "Make summary"
+    - make summary
+    - make summary.md
+    - cat build/results/summary.md && rm build/results/summary.md
+    - make check-status
+  artifacts:
+    when: always
+    paths:
+      - tests/opentitan/opentitan_parsing_test/build/
+
+
+bsg_test_diff:
+  stage: optional_bsg_tests
+  dependencies: [build_binaries]
+  when: manual
+  only:
+    - main
+    - merge_requests
+  script:
+    - echo "Install dependencies"
+    - apt update
+    - apt install -y $DEPENDENCIES_FOR_TESTING
+    - echo "Load submodules"
+    - git submodule sync
+    - git submodule update --depth 1 --init --recursive --checkout third_party/bsg_micro_designs
+    - echo "Start bsg diff test"
+    - export PATH="$PWD/out/current/bin:$PATH"
+    - python3 ./tests/bsg_micro_designs/generate_bsg_tests.py
+    - cat tests/bsg_micro_designs/build/bsg_micro_designs_summary.md
+  artifacts:
+    when: always
+    paths:
+      - tests/bsg_micro_designs/build/

--- a/frontends/systemverilog/uhdm_ast.h
+++ b/frontends/systemverilog/uhdm_ast.h
@@ -208,6 +208,7 @@ class UhdmAst
     static const ::Yosys::IdString &is_simplified_wire();
     static const ::Yosys::IdString &low_high_bound();
     static const ::Yosys::IdString &is_elaborated_module();
+    static const ::Yosys::IdString &expand_genblock();
 };
 
 // Utility for building AstNode trees.

--- a/tests/formal/passlist.txt
+++ b/tests/formal/passlist.txt
@@ -82,6 +82,7 @@ simple:EnumBases/top.sv
 simple:EnumConcat/dut.v
 simple:EnumConcatenatedConst/top.sv
 simple:EnumConstX/top.sv
+simple:EnumInGenblock/top.sv
 simple:EnumInPackage/dut.sv
 simple:EnumItemReimport/top.sv
 simple:EnumParameterInNestedModules/top.sv
@@ -91,7 +92,6 @@ simple:event_implicit_expression_list/event_implicit.sv
 simple:ExpressionInIndex/top.sv
 simple:FileLevelParameter/top.sv
 simple:FileLevelUnionWithMultirange/top.sv
-simple:fsm_single_always/dut.v
 simple:fsm_using_always/dut.v
 simple:fsm_using_function/dut.v
 simple:Function2Returns/top.sv
@@ -155,6 +155,7 @@ simple:NestedParamSubstitution/top.sv
 simple:NestedSelectOnInputPortInGenscope/top.sv
 simple:NestedSelectOnVarInGenscope/top.sv
 simple:NestedStructArrayParameterInitializedByPatternPassedAsPort/top.sv
+simple:NestedStructs/top.sv
 simple:NoEdge/dut.sv
 simple:NoLatch/dut.sv
 simple:OneAlwaysComb/dut.v
@@ -172,6 +173,7 @@ simple:PackageEnumConstPush/dut.sv
 simple:PackageLogicTypespec/dut.sv
 simple:PackedArray/top.sv
 simple:PackedArrayPort/top.sv
+simple:PackedInGenblock/top.sv
 simple:ParameterColonReference/top.sv
 simple:ParameterConditionalAssignment/top.sv
 simple:ParameterDoubleUnderscoreInSvFrontend/my_pkg.sv
@@ -336,7 +338,6 @@ sv2v:core/enum_typedef_keep.sv
 sv2v:core/enum_typedef_keep.v
 sv2v:core/for_loop_inits.v
 sv2v:core/function_range_cast.v
-sv2v:core/function_ret_unpacked.v
 sv2v:core/function_void.v
 sv2v:core/func_no_asgn.sv
 sv2v:core/func_no_asgn.v
@@ -598,7 +599,6 @@ yosys:asicworld/code_tidbits_asyn_reset.v
 yosys:asicworld/code_tidbits_blocking.v
 yosys:asicworld/code_tidbits_fsm_using_always.v
 yosys:asicworld/code_tidbits_fsm_using_function.v
-yosys:asicworld/code_tidbits_fsm_using_single_always.v
 yosys:asicworld/code_tidbits_nonblocking.v
 yosys:asicworld/code_tidbits_reg_combo_example.v
 yosys:asicworld/code_tidbits_reg_seq_example.v
@@ -632,7 +632,6 @@ yosys:bind/cell_list.sv
 yosys:bind/inst_list.sv
 yosys:errors/syntax_err09.v
 yosys:errors/syntax_err13.v
-yosys:fmt/always_comb.v
 yosys:hana/test_parser.v
 yosys:hana/test_simulation_and.v
 yosys:hana/test_simulation_decoder.v
@@ -641,7 +640,6 @@ yosys:memlib/memlib_clock_sdp.v
 yosys:memlib/memlib_lut.v
 yosys:memlib/memlib_multilut.v
 yosys:memlib/memlib_wide_read.v
-yosys:memlib/memlib_wide_sdp.v
 yosys:memlib/memlib_wide_sp.v
 yosys:memlib/memlib_wide_write.v
 yosys:memories/firrtl_938.v
@@ -664,11 +662,8 @@ yosys:memories/wide_write.v
 yosys:opt/opt_rmdff_sat.v
 yosys:opt/opt_share_diff_port_widths.v
 yosys:opt/opt_share_extend.v
-yosys:opt/opt_share_large_pmux_cat.v
 yosys:opt/opt_share_large_pmux_cat_multipart.v
 yosys:opt/opt_share_large_pmux_multipart.v
-yosys:opt/opt_share_large_pmux_part.v
-yosys:opt/opt_share_mux_tree.v
 yosys:proc/bug_1268.v
 yosys:proc/rmdead.v
 yosys:sat/alu.v
@@ -735,7 +730,6 @@ yosys:simple/loop_var_shadow.v
 yosys:simple/macros.v
 yosys:simple/macro_arg_surrounding_spaces.v
 yosys:simple/matching_end_labels.sv
-yosys:simple/mem2reg_bounds_tern.v
 yosys:simple/memwr_port_connection.sv
 yosys:simple/mem_arst.v
 yosys:simple/module_scope.v
@@ -751,6 +745,7 @@ yosys:simple/retime.v
 yosys:simple/rotate.v
 yosys:simple/scopes.v
 yosys:simple/signedexpr.v
+yosys:simple/sign_part_assign.v
 yosys:simple/specify.v
 yosys:simple/string_format.v
 yosys:simple/subbytes.v
@@ -778,8 +773,8 @@ yosys:various/attrib07_func_call.v
 yosys:various/constmsk_test.v
 yosys:various/const_func_block_var.v
 yosys:various/countbits.sv
-yosys:various/dynamic_part_select/forloop_select.v
 yosys:various/dynamic_part_select/forloop_select_gate.v
+yosys:various/dynamic_part_select/forloop_select_nowrshmsk.v
 yosys:various/dynamic_part_select/latch_002.v
 yosys:various/dynamic_part_select/latch_002_gate.v
 yosys:various/dynamic_part_select/latch_002_gate_good.v
@@ -794,11 +789,9 @@ yosys:various/dynamic_part_select/original_gate.v
 yosys:various/dynamic_part_select/reset_test.v
 yosys:various/dynamic_part_select/reset_test_gate.v
 yosys:various/dynamic_part_select/reversed_gate.v
-yosys:various/elab_sys_tasks.sv
 yosys:various/gen_if_null.v
 yosys:various/pmux2shiftx.v
 yosys:various/reg_wire_error.sv
-yosys:various/smtlib2_module.v
 yosys:various/sub.v
 yosys:verific/case.sv
 yosys:verilog/bug656.v

--- a/tests/formal/skiplist.txt
+++ b/tests/formal/skiplist.txt
@@ -53,12 +53,22 @@
 # This test sometimes fails due to how yosys assigns
 # wires to cells and the fact, that currently formal verification
 # requires the same order of assignments
+simple:fsm_single_always/dut.v
+yosys:simple/fsm.v
+yosys:fmt/always_comb.v
 yosys:opt/opt_lut.v
 yosys:simple/always03.v
 yosys:simple/operators.v
 yosys:asicworld/code_verilog_tutorial_fsm_full.v
 yosys:asicworld/code_hdl_models_GrayCounter.v
 yosys:simple/sincos.v
+yosys:asicworld/code_tidbits_fsm_using_single_always.v
+yosys:opt/opt_share_large_pmux_cat.v
+yosys:opt/opt_share_large_pmux_part.v
+yosys:opt/opt_share_mux_tree.v
+yosys:simple/mem2reg_bounds_tern.v
+yosys:various/elab_sys_tasks.sv
+yosys:various/smtlib2_module.v
 ########################################################################################
 # Type parameters in top modules cause the modules to be renamed
 # and handled incorrectly in verification scripts.

--- a/tests/simple_tests/EnumInGenblock/Makefile.in
+++ b/tests/simple_tests/EnumInGenblock/Makefile.in
@@ -1,0 +1,2 @@
+TEST_FILES := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/simple_tests/EnumInGenblock/top.sv
+++ b/tests/simple_tests/EnumInGenblock/top.sv
@@ -1,0 +1,31 @@
+module top();
+	if (1) begin : n
+		typedef enum logic [1:0] {
+			ALBL, ALBH, AHBL, AHBH
+		} mult_fsm_e;
+		mult_fsm_e mult_state_q, mult_state_d;
+
+		logic [1:0] a, b, c;
+
+		always_comb begin
+			unique case (mult_state_q)
+			ALBL: begin
+				a = 0;
+				c = ALBH;
+			end
+			ALBH: begin
+				a = 1;
+				c = AHBL;
+			end
+			AHBL: begin
+				a = 2;
+				c = AHBH;
+			end
+			AHBH: begin
+				a = 3;
+				c = ALBL;
+			end
+			endcase
+		end
+	end
+endmodule

--- a/tests/simple_tests/EnumInGenblock/yosys_script.tcl
+++ b/tests/simple_tests/EnumInGenblock/yosys_script.tcl
@@ -1,0 +1,6 @@
+source ../yosys_common.tcl
+
+prep -top \\top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/simple_tests/GenblockAlwaysFor/Makefile.in
+++ b/tests/simple_tests/GenblockAlwaysFor/Makefile.in
@@ -1,0 +1,2 @@
+TEST_FILES := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/simple_tests/GenblockAlwaysFor/top.sv
+++ b/tests/simple_tests/GenblockAlwaysFor/top.sv
@@ -1,0 +1,41 @@
+typedef enum integer { pN = 0, pB = 1, pO = 2, pF = 3 } p_e;
+typedef enum logic [6:0] { ALU_N, ALU_B, ALU_H, ALU_BFP } op;
+module top #(parameter p_e p = pF) (input op i);
+	if (p != pN) begin : gen1
+		if (p == pO || p == pF) begin : gen2
+			logic  [7:0][2:0] sel_n;
+			logic  [3:0][1:0] sel_b;
+			logic  [1:0][0:0] sel_h;
+
+			logic [7:0][2:0] sel;
+
+			always_comb begin
+				unique case (i)
+					ALU_N: begin
+						sel = sel_n;
+					end
+
+					ALU_B: begin
+						for (int b = 0; b < 4; b++) begin
+							sel[b*2 +  0] =   {sel_b[b], 1'b0};
+							sel[b*2 +  1] =   {sel_b[b], 1'b1};
+						end
+					end
+
+					ALU_H: begin
+						for (int h = 0; h < 2; h++) begin
+							sel[h*4 +  0] =   {sel_h[h], 2'b00};
+							sel[h*4 +  1] =   {sel_h[h], 2'b01};
+							sel[h*4 +  2] =   {sel_h[h], 2'b10};
+							sel[h*4 +  3] =   {sel_h[h], 2'b11};
+						end
+					end
+
+					default: begin
+						sel = sel_n;
+					end
+				endcase
+			end
+		end
+	end
+endmodule

--- a/tests/simple_tests/GenblockAlwaysFor/yosys_script.tcl
+++ b/tests/simple_tests/GenblockAlwaysFor/yosys_script.tcl
@@ -1,0 +1,13 @@
+source ../yosys_common.tcl
+
+proc_clean
+proc_rmdead
+proc_prune
+proc_init
+proc_arst
+proc_mux
+proc_dff
+proc_clean
+proc_dlatch
+opt
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/simple_tests/GenblockPackedAccess/Makefile.in
+++ b/tests/simple_tests/GenblockPackedAccess/Makefile.in
@@ -1,0 +1,2 @@
+TEST_FILES := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/simple_tests/GenblockPackedAccess/top.sv
+++ b/tests/simple_tests/GenblockPackedAccess/top.sv
@@ -1,0 +1,13 @@
+module top();
+	if (1) begin : n
+		typedef struct packed {
+			struct packed {
+				logic a;
+				logic b;
+			} foo;
+		} bar;
+		bar x;
+	end
+	assign n.x.foo.a = 0;
+	assign n.x.foo.b = 0;
+endmodule

--- a/tests/simple_tests/GenblockPackedAccess/yosys_script.tcl
+++ b/tests/simple_tests/GenblockPackedAccess/yosys_script.tcl
@@ -1,0 +1,6 @@
+source ../yosys_common.tcl
+
+prep -top \\top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/simple_tests/MultipleNestedStructs/Makefile.in
+++ b/tests/simple_tests/MultipleNestedStructs/Makefile.in
@@ -1,0 +1,2 @@
+TEST_FILES := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/simple_tests/MultipleNestedStructs/top.sv
+++ b/tests/simple_tests/MultipleNestedStructs/top.sv
@@ -1,0 +1,35 @@
+typedef struct packed {
+	struct packed {
+		logic a;
+	} foo;
+} foo;
+parameter int x = 1;
+module top();
+	typedef struct packed {
+		struct packed {
+			logic a;
+			logic b;
+		} foo;
+	} bar2;
+	typedef struct packed {
+		struct packed {
+			logic [2:0] a;
+			logic [3:0] b;
+		} foo;
+		foo bar;
+	} bar3;
+
+	foo  a;
+	bar2 b;
+	bar3 c;
+
+	assign a.foo.a = 1;
+
+	assign b.foo.a = 0;
+	assign b.foo.b = 1;
+
+	assign c.foo.a = 3;
+	assign c.foo.b = 5;
+	assign c.bar.a = 0;
+
+endmodule

--- a/tests/simple_tests/MultipleNestedStructs/yosys_script.tcl
+++ b/tests/simple_tests/MultipleNestedStructs/yosys_script.tcl
@@ -1,0 +1,6 @@
+source ../yosys_common.tcl
+
+prep -top \\top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/simple_tests/NestedStructs/Makefile.in
+++ b/tests/simple_tests/NestedStructs/Makefile.in
@@ -1,0 +1,2 @@
+TEST_FILES := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/simple_tests/NestedStructs/top.sv
+++ b/tests/simple_tests/NestedStructs/top.sv
@@ -1,0 +1,22 @@
+typedef struct packed {
+	struct packed {
+		 logic a;
+	} foo;
+} bar1;
+
+parameter int x = 1;
+module top();
+	typedef struct packed {
+		struct packed {
+			logic a;
+			logic b;
+		} foo;
+	} bar2;
+
+	bar1 a;
+	bar2 b;
+
+	assign a.foo.a = 1;
+	assign b.foo.a = 0;
+	assign b.foo.b = 1;
+endmodule

--- a/tests/simple_tests/NestedStructs/yosys_script.tcl
+++ b/tests/simple_tests/NestedStructs/yosys_script.tcl
@@ -1,0 +1,6 @@
+source ../yosys_common.tcl
+
+prep -top \\top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/simple_tests/PackedInGenblock/Makefile.in
+++ b/tests/simple_tests/PackedInGenblock/Makefile.in
@@ -1,0 +1,2 @@
+TEST_FILES := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/simple_tests/PackedInGenblock/top.sv
+++ b/tests/simple_tests/PackedInGenblock/top.sv
@@ -1,0 +1,12 @@
+parameter int enableFoo = 1;
+typedef struct packed {
+	logic [3:0] a;
+	logic [3:0] b;
+} packed_t;
+module top();
+	if (enableFoo) begin : foo
+		typedef struct packed {
+			packed_t bar;
+		} packed_packed_t;
+	end
+endmodule

--- a/tests/simple_tests/PackedInGenblock/yosys_script.tcl
+++ b/tests/simple_tests/PackedInGenblock/yosys_script.tcl
@@ -1,0 +1,6 @@
+source ../yosys_common.tcl
+
+prep -top \\top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/tests/simple_tests/ScopeOverwriting/Makefile.in
+++ b/tests/simple_tests/ScopeOverwriting/Makefile.in
@@ -1,0 +1,2 @@
+TEST_FILES := $(TEST_DIR)/top.sv
+TOP_MODULE := top

--- a/tests/simple_tests/ScopeOverwriting/top.sv
+++ b/tests/simple_tests/ScopeOverwriting/top.sv
@@ -1,0 +1,18 @@
+module top();
+	typedef struct {
+		logic a;
+		logic b;
+	} pair_t;
+
+	pair_t x;
+
+	if (1) begin : gen1
+		if (1) begin : gen2
+			logic x;
+		end
+	end
+	logic y;
+	always_comb begin : gen3
+		assign y = x.a;
+	end
+endmodule

--- a/tests/simple_tests/ScopeOverwriting/yosys_script.tcl
+++ b/tests/simple_tests/ScopeOverwriting/yosys_script.tcl
@@ -1,0 +1,6 @@
+source ../yosys_common.tcl
+
+prep -top \\top
+write_verilog
+write_verilog yosys.sv
+sim -rstlen 10 -vcd dump.vcd

--- a/third_party/yosys_mod/synlig_simplify.h
+++ b/third_party/yosys_mod/synlig_simplify.h
@@ -4,4 +4,5 @@ namespace systemverilog_plugin
 {
 using ys_size_type = int; // Makes it easy to change if changed upstream.
 bool simplify(Yosys::AST::AstNode *ast_node, bool const_fold, bool at_zero, bool in_lvalue, int stage, int width_hint, bool sign_hint, bool in_param);
+void synlig_expand_genblock(Yosys::AST::AstNode *current_node, std::string prefix, bool only_resolve_scope);
 } // namespace systemverilog_plugin


### PR DESCRIPTION
This PR updates yosys and adjusts synlig to it:

* rework the way, that synlig handles AST_GENBLOCK's,
* allow typedefing nested structs and unions inside AST_GENBLOCK's,
* add new simple tests,
* minor bugfixes.