### PR TITLE
Unify functions naming in yosys_mod and remove unnecessary calls to yosys functions

### DIFF
--- a/third_party/yosys_mod/synlig_const2ast.h
+++ b/third_party/yosys_mod/synlig_const2ast.h
@@ -7,7 +7,7 @@
 namespace systemverilog_plugin
 {
 // this function converts a Verilog constant to an AST_CONSTANT node
-Yosys::AST::AstNode *const2ast(std::string code, char case_type = 0, bool warn_z = false);
+Yosys::AST::AstNode *synlig_const2ast(std::string code, char case_type = 0, bool warn_z = false);
 } // namespace systemverilog_plugin
 
 #endif // SYSTEMVERILOG_PLUGIN_CONST2AST_H

--- a/third_party/yosys_mod/synlig_simplify.h
+++ b/third_party/yosys_mod/synlig_simplify.h
@@ -3,6 +3,7 @@
 namespace systemverilog_plugin
 {
 using ys_size_type = int; // Makes it easy to change if changed upstream.
-bool simplify(Yosys::AST::AstNode *ast_node, bool const_fold, bool at_zero, bool in_lvalue, int stage, int width_hint, bool sign_hint, bool in_param);
+bool synlig_simplify(Yosys::AST::AstNode *ast_node, bool const_fold, bool at_zero, bool in_lvalue, int stage, int width_hint, bool sign_hint,
+                     bool in_param);
 void synlig_expand_genblock(Yosys::AST::AstNode *current_node, std::string prefix, bool only_resolve_scope);
 } // namespace systemverilog_plugin


### PR DESCRIPTION
This PR ensures that all functions in `yosys_mod.cc` are prefixed with `synlig_`.
It also makes sure that code from `yosys_mod` calls functions (if available) from `yosys_mod`, not directly from yosys.