### PR TITLE
Update yosys version to 0.44

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -376,7 +376,7 @@ jobs:
           overwrite: true
           file_glob: true
 
-# Synlig requires yosys version 0.39 or later 
+# Synlig requires yosys version 0.40 or later 
 # which is currently not available in debian repositories.
 # This test can be uncommented when required version will be available.
 #  test-release-with-packaged-yosys:
@@ -462,7 +462,7 @@ jobs:
           (tuttest README.md path-setup; tuttest README.md example-uhdm-ver2) | bash -
           tuttest README.md example-multiple-files | (. <(tuttest README.md path-setup) && yosys)
 
-# Synlig requires yosys version 0.39 or later 
+# Synlig requires yosys version 0.40 or later 
 # which is currently not available in debian repositories.
 # This test can be uncommented when required version will be available.
 #  test-plugin-with-packaged-yosys:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Before installing the plugin, check that Yosys is installed and correctly config
    yosys-config --help
 ```
 
-The required Yosys version is 0.39 or later.
+The required Yosys version is 0.40 or later.
 Note that the yosys package with required version is currently unavailable in any Debian repository.
 If you don't have Yosys, skip to the [Installation from source](#installation-from-source) section to build Yosys from the source.
 

--- a/tests/opentitan/0001_Add_opentitan_patch_for_uhdm.patch
+++ b/tests/opentitan/0001_Add_opentitan_patch_for_uhdm.patch
@@ -146,13 +146,14 @@ index 8d6cf89b6..6480e08ba 100644
      toplevel: top_earlgrey_nexysvideo
      parameters:
        - BootRomInitFile
-@@ -64,6 +64,15 @@ targets:
+@@ -64,6 +64,16 @@ targets:
      tools:
        vivado:
          part: "xc7a200tsbg484-1" # Nexys Video
 +        synth: "yosys"
 +        yosys_synth_options: ['-flatten', '-iopad', '-noclkbuf', '-family xc7', "frontend=surelog"]
 +        yosys_read_options: ['-noassert', '-dump_ast1', '-dump_ast2', '-no_dump_ptr']
++        yosys_extra_passes: ['delete */t:\$scopeinfo']
 +        surelog_options: ['-DSYNTHESIS', '-synth']
 +      yosys:
 +        arch: "xilinx"

--- a/third_party/Build.yosys.mk
+++ b/third_party/Build.yosys.mk
@@ -65,7 +65,7 @@ endif
 # Variable evaluation: in recipe, ${var}
 define ${ts}.build_command
 		cd ${${ts}.src_dir}
-		${MAKE} ${${ts}.make_args} --no-print-directory
+		${MAKE} ${${ts}.make_args} --no-print-directory ENABLE_LTO=0
 endef
 
 define ${ts}.install_command

--- a/third_party/yosys_mod/synlig_simplify.cc
+++ b/third_party/yosys_mod/synlig_simplify.cc
@@ -852,7 +852,7 @@ bool synlig_simplify(Yosys::AST::AstNode *ast_node, bool const_fold, bool at_zer
             // when $display()/$write() functions are used in an initial block, print them during synthesis
             Fmt fmt = ast_node->processFormat(stage, /*sformat_like=*/false, default_base);
             if (ast_node->str.substr(0, 8) == "$display")
-                fmt.append_string("\n");
+                fmt.append_literal("\n");
             log("%s", fmt.render().c_str());
         } else {
             // when $display()/$write() functions are used in an always block, simplify the expressions and


### PR DESCRIPTION
This commit also disables creating `$scopeinfo` cells in large designs tests.

`$scopeinfo` is Yosys internal cell and should be removed before passing netlist to another tool.