### PR TITLE
Fix exit code in Formal Verification results.py

### DIFF
--- a/tests/formal/results.py
+++ b/tests/formal/results.py
@@ -132,4 +132,4 @@ def main():
     return 0
 
 if __name__ == "__main__":
-    main()
+    exit(main())

--- a/tests/formal/run.py
+++ b/tests/formal/run.py
@@ -63,7 +63,7 @@ def prepare_eqy_script(output_dir, script_name, plugin_file, yosys_file):
         "",
         "[gate]",
         "plugin -i systemverilog",
-        "tee -o %s/%s/plugin_ast.txt read_systemverilog -debug %s" % (output_dir, script_name, plugin_file),
+        "tee -o %s/%s/plugin_ast.txt read_systemverilog -nocache -debug %s" % (output_dir, script_name, plugin_file),
         "prep -flatten -auto-top",
         "opt",
         "",


### PR DESCRIPTION
Currently formal verification script `results.py` is only returning value that should be exit code, but it always exits with 0.
This PR fixes this.

We also noticed some issue with Surelog cache in formal verification, so as a workaround, we are disabling it temporarily.
