### PR TITLE
Update testing README with tuttest

### DIFF
--- a/.ci.yml
+++ b/.ci.yml
@@ -299,6 +299,38 @@ ibex_synth_f4pga_large_design:
     - eval $SETUP_TOOLS && export PATH="$PATH:$TOOLS_HOME/bin"
     - ./tests/scripts/run_large_designs.sh --name ibex_f4pga load_submodules run
 
+check_README:
+  stage: "Optional tests"
+  only:
+    - main
+    - merge_requests
+  variables:
+    SCALENODE_RAM: 8000
+    SCALENODE_CPU: 6
+  script:
+    - echo "##/ Install Prerequisites \##"
+    - apt update && apt install -y pipx git wget
+    - pipx install git+https://github.com/antmicro/tuttest#egg=tuttest
+    - export PATH=$PATH:/root/.local/bin
+    - echo "##/ Set pipefail \##"
+    - set -o pipefail
+    - echo "##/ Install dependencies \##"
+    - tuttest README.md install-dependencies | bash -
+    - echo "##/ Test make install \##"
+    - tuttest README.md make-install | bash -
+    - echo "##/ Test make tools \##"
+    - tuttest README.md get-haskell | bash -
+    - tuttest README.md install-tools | bash -
+    - echo "##/ Test counter.sv synthesis \##"
+    - tuttest README.md counter.sv > counter.sv
+    - tuttest README.md synthesis-example  | grep ">" | cut -d ">" -f 2 | synlig
+    - echo "##/ Test parsing multiple files \##"
+    - tuttest README.md example-multiple-files | synlig
+    - echo "##/ Test testing scripts commands \##"
+    - tuttest README.md formal-verification-help | bash -
+    - tuttest README.md large-designs-help | bash -
+    - tuttest README.md parsing-tests-help | bash -
+
 bsg_test_diff:
   stage: "Optional tests"
   dependencies: [build_plugin]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -377,60 +377,10 @@ jobs:
           overwrite: true
           file_glob: true
 
-# Synlig requires yosys version 0.40 or later 
-# which is currently not available in debian repositories.
-# This test can be uncommented when required version will be available.
-#  test-release-with-packaged-yosys:
-#    name: Release Package Installation Test
-#    runs-on: [self-hosted, Linux, X64]
-#    container: debian:sid
-#    needs: release
-#    env:
-#      DEBIAN_FRONTEND: noninteractive
-#      PIPX_BIN_DIR: /usr/local/bin
-#
-#    steps:
-#      - name: Prepare Repository
-#        uses: actions/checkout@v2
-#        with:
-#          fetch-depth: 1
-#
-#      - name: Install Prerequisites
-#        run: |
-#          apt update -qq
-#          apt install -y --no-install-recommends pipx git
-#          pipx install git+https://github.com/antmicro/tuttest#egg=tuttest
-#
-#      - name: Install Dependencies
-#        run: |
-#          tuttest README.md install-yosys-debian | bash -
-#
-#      - name: Install Plugin
-#        run: |
-#          tuttest README.md download-plugin | bash -
-#          tuttest README.md install-plugin | bash -
-#
-#      - name: Load Plugin
-#        run: |
-#          tuttest README.md load-plugin | yosys -Q | tee log.txt
-#          grep ^ERROR log.txt || exit 0
-#          exit 1
-#
-#      - name: Test Plugin
-#        run: |
-#          tuttest README.md example-verilog | bash -
-#          tuttest README.md example-multiple-files | yosys
-#
-#      - name: Test sv2v pull and build
-#        run: |
-#          export PATH=`pwd`/out/current/bin:$PATH
-#          tuttest README.md sv2v-update | bash -
-#          tuttest README.md sv2v-build | bash -
-
-  test-readme-install-from-source:
-    name: Test "Installation from source" from README
+  verify-README:
+    name: Verify README Correctness (Installation From Sources)
     runs-on: [self-hosted, Linux, X64, gcp-custom-runners]
-    container: debian:trixie
+    container: debian:bookworm
     env:
       DEBIAN_FRONTEND: noninteractive
       PIPX_BIN_DIR: /usr/local/bin
@@ -444,126 +394,72 @@ jobs:
       - name: Install Prerequisites
         run: |
           apt update -qq
-          apt install -y --no-install-recommends pipx git
+          apt install -y --no-install-recommends pipx git wget
           pipx install git+https://github.com/antmicro/tuttest#egg=tuttest
+
+      - name: Set Pipefail
+        run: |
+          set -o pipefail
 
       - name: Install Dependencies
         run: |
-          tuttest README.md dependencies | bash -
+          tuttest README.md install-dependencies | bash -
 
-      - name: Build Binaries
+      - name: Test Synlig Installation
         run: |
-          tuttest README.md build-binaries | bash -
+          tuttest README.md make-install | bash -
 
-      - name: Test Binaries
+      - name: Test Tools Installation
         run: |
-          tuttest README.md load-plugin | (. <(tuttest README.md path-setup) && yosys)
-          (tuttest README.md path-setup; tuttest README.md example-verilog) | bash -
-          (tuttest README.md path-setup; tuttest README.md example-uhdm-ver1) | bash -
-          (tuttest README.md path-setup; tuttest README.md example-uhdm-ver2) | bash -
-          tuttest README.md example-multiple-files | (. <(tuttest README.md path-setup) && yosys)
+          tuttest README.md get-haskell | bash -
+          tuttest README.md install-tools | bash -
 
-# Synlig requires yosys version 0.40 or later 
-# which is currently not available in debian repositories.
-# This test can be uncommented when required version will be available.
-#  test-plugin-with-packaged-yosys:
-#    name: Test With Packaged Yosys
-#    runs-on: [self-hosted, Linux, X64]
-#    container: debian:sid
-#    needs: build-binaries
-#    env:
-#      DEBIAN_FRONTEND: noninteractive
-#      PIPX_BIN_DIR: /usr/local/bin
-#
-#    steps:
-#      - uses: actions/checkout@v3
-#        with:
-#          submodules: false
-#          fetch-depth: 1
-#
-#      - name: Download binaries
-#        uses: actions/download-artifact@v2
-#        with:
-#          name: binaries-debian
-#
-#      - name: Extract
-#        run: tar -xf binaries-debian.tar
-#
-#      - name: Install Yosys & Plugin
-#        run: |
-#          apt update -q
-#          apt install -y yosys yosys-dev
-#          ./install_plugin.sh
-#
-#      - name: Load Plugin
-#        run: |
-#          yosys -Q -m systemverilog \
-#              -p "help read_systemverilog" \
-#              -p "help read_uhdm" 2>&1 | tee log.txt
-#          grep ^ERROR log.txt || exit 0
-#          exit 1
+      - name: Test counter.sv Synthesis
+        run: |
+          tuttest README.md counter.sv > counter.sv
+          tuttest README.md synthesis-example  | grep ">" | cut -d ">" -f 2 | synlig
 
-  test-plugin-with-bundled-yosys:
-    name: Test With Bundled Yosys
+      - name: Test Parsing Multiple Files
+        run: |
+          tuttest README.md example-multiple-files | synlig
+
+      - name: Test Testing Scripts Commands
+        run: |
+          tuttest README.md formal-verification-help | bash -
+          tuttest README.md large-designs-help | bash -
+          tuttest README.md parsing-tests-help | bash -
+
+  test-package:
+    name: Verify README Correctness (Download And Run Release)
+    needs: release
     runs-on: [self-hosted, Linux, X64, gcp-custom-runners]
-    container: debian:trixie
-    needs: build-binaries
+    container: debian:bookworm
     env:
       DEBIAN_FRONTEND: noninteractive
       PIPX_BIN_DIR: /usr/local/bin
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Prepare Repository
+        uses: actions/checkout@v2
         with:
-          submodules: false
           fetch-depth: 1
 
       - name: Install Prerequisites
         run: |
           apt update -qq
-          apt install -y --no-install-recommends pipx git
+          apt install -y --no-install-recommends pipx jq curl wget
           pipx install git+https://github.com/antmicro/tuttest#egg=tuttest
 
-      - name: Install Dependencies
+      - name: Set Pipefail
         run: |
-          # Don't need all the build dependencies, but will ensure everything
-          # yosys needs at runtime will be installed
-          tuttest README.md dependencies | bash -
+          set -o pipefail
 
-      - name: Download binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: binaries-plugin
-
-      - name: Extract
+      - name: Download Release And Set PATH
         run: |
-          # Extract into a different directory than it was built in
-          # to ensure no path dependencies
-          tar --one-top-level -xf binaries-plugin.tar
+          tuttest README.md download-release | bash -
+          eval $(tuttest README.md path-setup)
 
-      - name: Verify yosys-config
+      - name: Test counter.sv Synthesis
         run: |
-          # Check that the directories reported by yosys-config exist
-          echo "yosys-config reports data directory is" $(binaries-debian/out/current/bin/yosys-config --datdir)
-          ls $(binaries-debian/out/current/bin/yosys-config --datdir) > /dev/null
-
-      - name: Load Plugin
-        run: |
-          binaries-debian/out/current/bin/yosys \
-              -Q -m systemverilog \
-              -p "help read_systemverilog" \
-              -p "help read_uhdm" 2>&1 | tee log.txt
-          grep ^ERROR log.txt || exit 0
-          exit 1
-
-  # needed for test linting
-  upload-event-file:
-    name: Upload GHA event file
-    runs-on: ubuntu-latest
-    steps:
-      - run: cp "$GITHUB_EVENT_PATH" ./event.json
-      - name: Upload event file as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: event.json
-          path: event.json
+          tuttest README.md counter.sv > counter.sv
+          tuttest README.md synthesis-example  | grep ">" | cut -d ">" -f 2 | synlig

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Synlig is a SystemVerilog synthesis tool that uses [Surelog](https://github.com/
 You can download Synlig from the GitHub [release page](https://github.com/chipsalliance/synlig/releases).
 To download the latest version, use the following script:
 
+<!-- name="download-release" -->
 ```bash
 curl https://api.github.com/repos/chipsalliance/synlig/releases/latest | jq -r '.assets | .[] | select(.name | startswith("synlig")) | .browser_download_url' | xargs wget -O - | tar -xz
 ```
@@ -27,11 +28,11 @@ Go to the [Usage](#usage) section of this document to learn how to use it.
 
 ### Installation from source
 
-Debian Trixie:
+Debian Bookworm:
 
 #### Install dependencies
 
-<!-- name="dependencies" -->
+<!-- name="install-dependencies" -->
 ``` bash
    apt install -y gcc-11 g++-11 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev python3-pip uuid uuid-dev tcl-dev flex libfl-dev git pkg-config libreadline-dev bison libffi-dev wget python3-orderedmultidict
 ```
@@ -41,7 +42,7 @@ Debian Trixie:
 You can build all required binaries using the provided `Makefile`.
 `make install` will build and install Synlig in `/usr/local` directory.
 
-<!-- name="build-binaries" -->
+<!-- name="make-install" -->
 ``` bash
    git submodule sync
    git submodule update --init --recursive third_party/{surelog,yosys}
@@ -87,7 +88,7 @@ endmodule
 
 Running synthesis using Synlig is very simple:
 
-<!-- name="synthesis example" -->
+<!-- name="synthesis-example" -->
 ``` tcl
 	> read_systemverilog counter.sv
 	1. Executing Verilog with UHDM frontend.
@@ -154,9 +155,20 @@ More information about formal verification can be found in this [README](https:/
 
 #### Prerequisites
 
+##### Dependencies
+
+Building `sv2v` requires Haskell Stack, you can install it by running:
+
+<!-- name="get-haskell" -->
+``` bash
+   wget -qO- https://get.haskellstack.org/ | sh -s - -f -d /usr/local/bin
+```
+
+##### Installation
+
 All required prerequisites can be installed by running:
 
-<!-- name="install tools" -->
+<!-- name="install-tools" -->
 ``` bash
    git submodule update --init --recursive --checkout third_party/{sv2v,eqy,sby,yosys}
    make tools -j $(nproc)
@@ -166,12 +178,14 @@ All required prerequisites can be installed by running:
 
 To start formal verification tests, use the dedicated script:
 
-<!-- name="run-fv-tests-exec" -->
+<!-- name="formal-verification-run" -->
 ``` bash
    ./tests/scripts/run_formal.sh --name=<test_suite_name> run
 ```
 
 To gather formal verification results, run:
+
+<!-- name="formal-verification-gather-results" -->
 ``` bash
    ./tests/scripts/run_formal.sh --name=<test_suite_name> gather_results
 ```
@@ -180,6 +194,7 @@ To gather formal verification results, run:
 
 You can see the available `test_suite_name` options by running:
 
+<!-- name="formal-verification-help" -->
 ``` bash
    ./tests/scripts/run_formal.sh --help
 ```
@@ -195,6 +210,7 @@ Synlig is also tested by synthesizing several designs:
 
 For more details, check `.github/workflows/large-designs.yml` or run:
 
+<!-- name="large-designs-help" -->
 ``` bash
    ./tests/scripts/run_large_designs.sh --help
 ```
@@ -203,6 +219,7 @@ For more details, check `.github/workflows/large-designs.yml` or run:
 
 Synlig is additionally tested with parsing tests. For more details check `.github/workflows/parsing-tests.yml` or run:
 
+<!-- name="parsing-tests-help" -->
 ``` bash
    ./tests/scripts/run_parsing.sh --help
 ```
@@ -230,7 +247,7 @@ Note that almost all tests are made using the Synlig binary instead of the plugi
 
 #### Install dependencies
 
-<!-- name="dependencies" -->
+<!-- name="install-dependencies-plugin" -->
 ``` bash
    apt install -y gcc-11 g++-11 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev python3-pip uuid uuid-dev tcl-dev flex libfl-dev git pkg-config libreadline-dev bison libffi-dev wget python3-orderedmultidict
 ```
@@ -241,7 +258,7 @@ You can build all required binaries using the provided `Makefile`.
 `make plugin` will build Surelog, Yosys and Synlig as a plugin, and place them in the `out` directory.
 You need to add `out/bin` to your `PATH` variable to ensure you are using correct versions of the binaries.
 
-<!-- name="build-binaries" -->
+<!-- name="build-plugin" -->
 ``` bash
    git submodule update --init --recursive third_party/{surelog,yosys}
    make plugin -j$(nproc)
@@ -249,7 +266,7 @@ You need to add `out/bin` to your `PATH` variable to ensure you are using correc
 
 To use Yosys built from a submodule, make sure to either use absolute paths, or update the `PATH` variable before use.
 
-<!-- name="path-setup" -->
+<!-- name="path-setup-plugin" -->
 ``` bash
    export PATH=`pwd`/out/current/bin:$PATH
 ```


### PR DESCRIPTION
This PR refactors verifying `README` with `tuttest`. Now CI:
- checks Synlig and tools installation from `README`,
- checks `README` examples,
- verifies downloadable release correctness.

This PR also removes some deprecated `README` tests.