### PR TITLE
Fix pushing logs to main branch of synlig-logs repo

### DIFF
--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -107,7 +107,7 @@ jobs:
     name: Generate AST diff
     runs-on: [self-hosted, Linux, X64, gcp-custom-runners]
     container: ubuntu:jammy
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event.push
+    if: (github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'))
     needs:
       - parsing-tests
     steps:


### PR DESCRIPTION
This PR fixes pushing tests logs after merge to allow visualize changes in AST in PRs.